### PR TITLE
fix: 🐛 json viewer

### DIFF
--- a/apps/app/src/app/panel/[panel]/components/SearchableExtensionDetails.tsx
+++ b/apps/app/src/app/panel/[panel]/components/SearchableExtensionDetails.tsx
@@ -323,7 +323,7 @@ export function SearchableExtensionDetails({
                     data={value}
                     title={ext.url.split('/').pop() || ext.url}
                     className="mt-1"
-                    isExpanded={true}
+                    isExpanded={false}
                     searchTerm={hasActiveSearch && isJson && useEnhancedHighlighting ? searchTerm : undefined}
                     searchMode={hasActiveSearch && isJson && useEnhancedHighlighting ? searchMode : undefined}
                     highlightMatches={hasActiveSearch && isJson && useEnhancedHighlighting}
@@ -345,7 +345,7 @@ export function SearchableExtensionDetails({
                     data={value}
                     title={ext.url.split('/').pop() || ext.url}
                     className="mt-1"
-                    isExpanded={true}
+                    isExpanded={false}
                     searchTerm={hasActiveSearch && isJson && useEnhancedHighlighting ? searchTerm : undefined}
                     searchMode={hasActiveSearch && isJson && useEnhancedHighlighting ? searchMode : undefined}
                     highlightMatches={hasActiveSearch && isJson && useEnhancedHighlighting}

--- a/apps/app/src/components/JsonViewer/HighlightedJsonViewer.tsx
+++ b/apps/app/src/components/JsonViewer/HighlightedJsonViewer.tsx
@@ -1,5 +1,5 @@
 import type React from 'react'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { ChevronDown, ChevronRight } from 'lucide-react'
 import type { HighlightedJsonProps } from './types'
 import {
@@ -26,6 +26,7 @@ export const HighlightedJsonViewer: React.FC<HighlightedJsonProps> = ({
 }) => {
     const [isExpanded, setIsExpanded] = useState(initialExpanded)
     const [matches, setMatches] = useState<ReturnType<typeof findSearchMatches>>([])
+    const hasBeenManuallyToggled = useRef(false)
 
     // Find matches when search term or data changes
     useEffect(() => {
@@ -39,7 +40,7 @@ export const HighlightedJsonViewer: React.FC<HighlightedJsonProps> = ({
 
     // Auto-expand/collapse based on search matches
     useEffect(() => {
-        if (highlightMatches && searchTerm) {
+        if (highlightMatches && searchTerm && !hasBeenManuallyToggled.current) {
             const shouldExpand = shouldAutoExpand(path, matches, autoCollapse)
             setIsExpanded(shouldExpand)
         }
@@ -48,6 +49,7 @@ export const HighlightedJsonViewer: React.FC<HighlightedJsonProps> = ({
     const handleToggle = () => {
         const newExpanded = !isExpanded
         setIsExpanded(newExpanded)
+        hasBeenManuallyToggled.current = true
         onToggle?.()
     }
 

--- a/apps/app/src/components/JsonViewer/JsonViewMode.tsx
+++ b/apps/app/src/components/JsonViewer/JsonViewMode.tsx
@@ -80,6 +80,7 @@ export function JsonViewMode({
     path = []
 }: JsonViewModeProps) {
     const [expanded, setExpanded] = useState(isExpanded);
+    const [hasBeenManuallyToggled, setHasBeenManuallyToggled] = useState(false);
 
     const isObject = typeof data === 'object' && data !== null && !Array.isArray(data);
     const isArray = Array.isArray(data);
@@ -94,16 +95,17 @@ export function JsonViewMode({
 
     // Auto-expand/collapse based on search matches - only run when necessary
     useEffect(() => {
-        if (highlightMatches && searchTerm && autoCollapse) {
+        if (highlightMatches && searchTerm && autoCollapse && !hasBeenManuallyToggled) {
             const shouldExpand = shouldAutoExpand(path, matches, autoCollapse)
             if (shouldExpand !== expanded) {
                 setExpanded(shouldExpand)
             }
         }
-    }, [matches, searchTerm, highlightMatches, autoCollapse, path, expanded])
+    }, [matches, searchTerm, highlightMatches, autoCollapse, path, expanded, hasBeenManuallyToggled])
 
     const handleToggle = () => {
         setExpanded(!expanded);
+        setHasBeenManuallyToggled(true);
         onToggle?.();
     };
 

--- a/apps/app/src/components/JsonViewer/SimplifiedJsonViewMode.tsx
+++ b/apps/app/src/components/JsonViewer/SimplifiedJsonViewMode.tsx
@@ -71,6 +71,7 @@ export function SimplifiedJsonViewMode({
     path = []
 }: JsonViewModeProps) {
     const [expanded, setExpanded] = useState(isExpanded);
+    const [hasBeenManuallyToggled, setHasBeenManuallyToggled] = useState(false);
 
     const isObject = typeof data === 'object' && data !== null && !Array.isArray(data);
     const isArray = Array.isArray(data);
@@ -85,16 +86,17 @@ export function SimplifiedJsonViewMode({
 
     // Auto-expand/collapse based on search matches - only run when necessary
     useEffect(() => {
-        if (highlightMatches && searchTerm && autoCollapse) {
+        if (highlightMatches && searchTerm && autoCollapse && !hasBeenManuallyToggled) {
             const shouldExpand = shouldAutoExpand(path, matches, autoCollapse)
             if (shouldExpand !== expanded) {
                 setExpanded(shouldExpand)
             }
         }
-    }, [matches, searchTerm, highlightMatches, autoCollapse, path, expanded])
+    }, [matches, searchTerm, highlightMatches, autoCollapse, path, expanded, hasBeenManuallyToggled])
 
     const handleToggle = () => {
         setExpanded(!expanded);
+        setHasBeenManuallyToggled(true);
         onToggle?.();
     };
 


### PR DESCRIPTION
**What we are doing?**
JSON Viewer chevron can be closed even in case of matches when the user searches for a term 
**Why?**
Because it is quite unusable for a user to have to scroll down a long JSON in cases of multiple matches, and if the interesting match is at the end of the list
