### PR TITLE
fix: 🐛 tasks

### DIFF
--- a/apps/app/src/app/panel/[panel]/components/SearchableExtensionDetails.tsx
+++ b/apps/app/src/app/panel/[panel]/components/SearchableExtensionDetails.tsx
@@ -278,16 +278,50 @@ export function SearchableExtensionDetails({
 
             return (
                 <div className="space-y-2">
-                    {sortedNestedExtensions.map((nestedExt: Extension, nestedIndex: number) => (
-                        <div key={`${parentIndex}-${nestedIndex}-${nestedExt.url}`} className="bg-gray-50 p-3 rounded">
-                            <div className="text-xs font-medium text-gray-500" title={`FHIR Path: extension${parentIndex !== undefined ? `[${parentIndex}]` : ''}.extension[${nestedIndex}]`}>
-                                {nestedExt.url}
+                    {sortedNestedExtensions.map((nestedExt: Extension, nestedIndex: number) => {
+                        const shouldRenderAsKeyValue = !isJsonExtension(nestedExt) &&
+                            (!nestedExt.extension || nestedExt.extension.length === 0)
+
+                        if (shouldRenderAsKeyValue) {
+                            const nestedKey = nestedExt.url.split('/').pop() || nestedExt.url
+                            const nestedValue = getExtensionTextValue(nestedExt)
+                            const isKeyLong = nestedKey.length > 30
+                            const isValueLong = String(nestedValue).length > 40
+
+                            if (!isKeyLong && !isValueLong) {
+                                // One-line layout
+                                return (
+                                    <div key={`${parentIndex}-${nestedIndex}-${nestedExt.url}`} className="flex items-start w-full space-x-2 text-sm">
+                                        <span className="font-medium min-w-0 flex-shrink-0 truncate max-w-[40%] text-sm text-gray-500" title={nestedKey}>
+                                            {nestedKey}:
+                                        </span>
+                                        <span className="text-sm break-words whitespace-pre-wrap flex-1">
+                                            {nestedValue}
+                                        </span>
+                                    </div>
+                                )
+                            }
+                            // Stacked layout
+                            return (
+                                <div key={`${parentIndex}-${nestedIndex}-${nestedExt.url}`} className="flex flex-col w-full text-sm">
+                                    <span className="font-medium text-sm mb-0.5 text-gray-500">{nestedKey}:</span>
+                                    <span className="text-sm break-words whitespace-pre-wrap pl-2">{nestedValue}</span>
+                                </div>
+                            )
+                        }
+
+                        // Use the original layout for JSON objects and nested extensions
+                        return (
+                            <div key={`${parentIndex}-${nestedIndex}-${nestedExt.url}`} className="flex flex-col w-full text-sm"> {/* bg-gray-50 p-3 rounded */}
+                                <div className="text-sm font-medium text-gray-500" title={`FHIR Path: extension${parentIndex !== undefined ? `[${parentIndex}]` : ''}.extension[${nestedIndex}]`}>
+                                    {nestedExt.url.split('/').pop() || nestedExt.url}:
+                                </div>
+                                <div className="text-sm">
+                                    {renderExtensionValue(nestedExt, nestedIndex)}
+                                </div>
                             </div>
-                            <div className="text-sm">
-                                {renderExtensionValue(nestedExt, nestedIndex)}
-                            </div>
-                        </div>
-                    ))}
+                        )
+                    })}
                 </div>
             )
         }
@@ -321,8 +355,8 @@ export function SearchableExtensionDetails({
             return (
                 <JsonViewerComponent
                     data={value}
-                    title={ext.url.split('/').pop() || ext.url}
-                    className="mt-1"
+                    title="a"
+                    className="mt-0"
                     isExpanded={false}
                     searchTerm={hasActiveSearch && isJson && useEnhancedHighlighting ? searchTerm : undefined}
                     searchMode={hasActiveSearch && isJson && useEnhancedHighlighting ? searchMode : undefined}
@@ -343,8 +377,8 @@ export function SearchableExtensionDetails({
             return (
                 <JsonViewerComponent
                     data={value}
-                    title={ext.url.split('/').pop() || ext.url}
-                    className="mt-1"
+                    title=" "
+                    className="mt-0"
                     isExpanded={false}
                     searchTerm={hasActiveSearch && isJson && useEnhancedHighlighting ? searchTerm : undefined}
                     searchMode={hasActiveSearch && isJson && useEnhancedHighlighting ? searchMode : undefined}

--- a/apps/app/src/app/panel/[panel]/components/TaskDetails.tsx
+++ b/apps/app/src/app/panel/[panel]/components/TaskDetails.tsx
@@ -104,7 +104,7 @@ export function TaskDetails({ taskData }: TaskContentProps) {
                   </div>
                 </div>
 
-                <div className="grid grid-cols-2 gap-4">
+                {/* <div className="grid grid-cols-2 gap-4">
                   <div className="bg-gray-50 p-3 rounded">
                     <p className="text-xs font-medium text-gray-500">Status</p>
                     <p className="text-sm">{taskData.status}</p>
@@ -123,9 +123,9 @@ export function TaskDetails({ taskData }: TaskContentProps) {
                     <p className="text-xs text-gray-500">Authored On</p>
                     <p className="text-sm">{formatDateWithType(taskData.authoredOn)}</p>
                   </div>
-                </div>
+                </div> */}
 
-                {taskData.executionPeriod && (
+                {/* {taskData.executionPeriod && (
                   <div className="bg-gray-50 p-3 rounded">
                     <p className="text-xs font-medium text-gray-500 mb-2">Execution Period</p>
                     <div className="grid grid-cols-2 gap-4">
@@ -143,7 +143,7 @@ export function TaskDetails({ taskData }: TaskContentProps) {
                       )}
                     </div>
                   </div>
-                )}
+                )} */}
 
                 {taskData.input && taskData.input.length > 0 && (() => {
                   // Filter out connector inputs (same logic as used for connectors section)
@@ -172,10 +172,11 @@ export function TaskDetails({ taskData }: TaskContentProps) {
                   );
                 })()}
 
-                {taskData.patient && (
+                {/* {taskData.patient && (
                   <PatientDetails patient={taskData.patient} />
-                )}
+                )} */}
 
+                <h3 className="text-sm font-medium mb-2">Context</h3>
                 {taskData.extension && (
                   isFeatureEnabled('ENABLE_EXTENSION_SEARCH') ? (
                     isFeatureEnabled('USE_JSON_VIEWER_FOR_EXTENSIONS') ? (


### PR DESCRIPTION
**What are we doing?**
Extension keys and values are rendered as a one-liner if both don't exceed 70 characters, otherwise stacked as before
**Why?**
Because the right pane is unreadable and messy, making it difficult to read the content properly

