### PR TITLE
feat: add patient deletion feature for testing

### DIFF
--- a/apps/app/src/app/panel/[panel]/components/ModalDetails/PatientDetails/PatientDetails.tsx
+++ b/apps/app/src/app/panel/[panel]/components/ModalDetails/PatientDetails/PatientDetails.tsx
@@ -1,7 +1,7 @@
 import type { WorklistPatient, WorklistTask } from '@/hooks/use-medplum-store'
 import PatientData from './PatientData'
 import TaskStatusBadge from '../TaskDetails/TaskStatusBadge'
-import { ChevronRightIcon } from 'lucide-react'
+import { ChevronRightIcon, Trash2Icon } from 'lucide-react'
 
 import NotesTimeline from '../NotesTimeline'
 import { sortBy } from 'lodash'
@@ -9,9 +9,14 @@ import { sortBy } from 'lodash'
 interface PatientDetailsProps {
   patient: WorklistPatient
   setSelectedTask: (task: WorklistTask | null) => void
+  onDeleteRequest: () => void
 }
 
-const PatientDetails = ({ patient, setSelectedTask }: PatientDetailsProps) => {
+const PatientDetails = ({
+  patient,
+  setSelectedTask,
+  onDeleteRequest,
+}: PatientDetailsProps) => {
   const VIEWS = ['data', 'content', 'timeline']
   const { tasks } = patient
   let notes: WorklistTask['note'] = []
@@ -36,7 +41,21 @@ const PatientDetails = ({ patient, setSelectedTask }: PatientDetailsProps) => {
           }`}
         >
           <div className="h-full p-2">
-            {view === 'data' && <PatientData patient={patient} />}
+            {view === 'data' && (
+              <div>
+                <div className="mb-4 pb-4 border-b border-gray-200">
+                  <button
+                    type="button"
+                    onClick={onDeleteRequest}
+                    className="flex items-center gap-2 px-3 py-2 text-sm text-red-600 hover:text-red-800 hover:bg-red-50 border border-red-200 rounded-md transition-colors"
+                  >
+                    <Trash2Icon className="w-4 h-4" />
+                    Delete Patient & Tasks
+                  </button>
+                </div>
+                <PatientData patient={patient} />
+              </div>
+            )}
             {view === 'timeline' && (
               <NotesTimeline thread={thread} patientId={patient.id} />
             )}

--- a/apps/app/src/hooks/use-medplum-store.ts
+++ b/apps/app/src/hooks/use-medplum-store.ts
@@ -110,6 +110,7 @@ export function useMedplumStore() {
     toggleTaskOwner,
     getPatientObservations,
     getPatientEncounters,
+    deletePatient,
   } = useMedplum()
 
   // Map the raw FHIR resources to our worklist format
@@ -132,5 +133,6 @@ export function useMedplumStore() {
     toggleTaskOwner,
     getPatientObservations,
     getPatientEncounters,
+    deletePatient,
   }
 }

--- a/apps/app/src/lib/medplum.ts
+++ b/apps/app/src/lib/medplum.ts
@@ -328,6 +328,34 @@ export class MedplumStore {
       throw error
     }
   }
+
+  async deletePatient(patientId: string): Promise<void> {
+    try {
+      // First, get all tasks for this patient
+      const tasksBundle = await this.client.search('Task', {
+        subject: `Patient/${patientId}`,
+      })
+
+      const tasks = (tasksBundle.entry || []).map(
+        (entry) => entry.resource as Task,
+      )
+
+      // Delete all tasks for this patient
+      await Promise.all(
+        tasks.map((task) =>
+          task.id
+            ? this.client.deleteResource('Task', task.id)
+            : Promise.resolve(),
+        ),
+      )
+
+      // Delete the patient
+      await this.client.deleteResource('Patient', patientId)
+    } catch (error) {
+      console.error('Error deleting patient:', error)
+      throw error
+    }
+  }
 }
 
 // Export a singleton instance


### PR DESCRIPTION
- Add deletePatient method to MedplumStore that deletes patient and all associated tasks
- Update MedplumClientProvider to expose deletePatient functionality
- Add delete button to PatientDetails component with modern toast notifications
- Replace browser alert/confirm dialogs with toast notifications from ToastContext
- Modal automatically closes after successful patient deletion
- Fix API search parameter from 'for' to 'subject' for FHIR Task resource queries

This feature is intended for testing purposes to allow cleanup of test data.