### PR TITLE
feat: add SelectCell component with smart status badge integration

### DIFF
--- a/apps/app/src/app/panel/[panel]/components/ModalDetails/TaskDetails/TaskStatusBadge.tsx
+++ b/apps/app/src/app/panel/[panel]/components/ModalDetails/TaskDetails/TaskStatusBadge.tsx
@@ -1,4 +1,4 @@
-const statuses = {
+export const statuses = {
   draft: {
     label: 'Draft',
     color: 'bg-gray-400',
@@ -47,6 +47,10 @@ const statuses = {
     label: 'Entered in error',
     color: 'bg-gray-400',
   },
+}
+
+export const isTaskStatus = (status: string): boolean => {
+  return status.toLowerCase() in statuses
 }
 
 const TaskStatusBadge = ({ status }: { status: string }) => {

--- a/apps/app/src/app/panel/[panel]/components/VirtualizedTable/cells/CellFactory.tsx
+++ b/apps/app/src/app/panel/[panel]/components/VirtualizedTable/cells/CellFactory.tsx
@@ -5,6 +5,7 @@ import { ArrayCell } from './ArrayCell'
 import { AssigneeCell } from './AssigneeCell'
 import { BaseCell } from './BaseCell'
 import { DateCell } from './DateCell'
+import { SelectCell } from './SelectCell'
 import type { InteractiveCellProps } from './types'
 import { DateTimeCell } from './DateTimeCell'
 
@@ -47,6 +48,9 @@ export function CellFactory(props: CellFactoryProps) {
 
     case 'user':
       return <AssigneeCell {...props} />
+
+    case 'select':
+      return <SelectCell {...props} />
 
     case 'boolean':
       return (

--- a/apps/app/src/app/panel/[panel]/components/VirtualizedTable/cells/SelectCell.tsx
+++ b/apps/app/src/app/panel/[panel]/components/VirtualizedTable/cells/SelectCell.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { BaseCell } from './BaseCell'
+import type { InteractiveCellProps } from './types'
+import TaskStatusBadge, {
+  isTaskStatus,
+} from '../../ModalDetails/TaskDetails/TaskStatusBadge'
+
+interface SelectCellProps extends InteractiveCellProps {
+  // Additional props specific to SelectCell can be added here
+}
+
+export function SelectCell(props: SelectCellProps) {
+  const { value } = props
+
+  return (
+    <BaseCell {...props}>
+      {value !== null && value !== undefined && value !== '' ? (
+        isTaskStatus(String(value)) ? (
+          <TaskStatusBadge status={String(value).toLowerCase()} />
+        ) : (
+          <div className="badge badge-soft badge-xs text-white bg-gray-400">
+            {String(value)}
+          </div>
+        )
+      ) : (
+        <span className="text-gray-500">-</span>
+      )}
+    </BaseCell>
+  )
+}


### PR DESCRIPTION
- Add new SelectCell component for 'select' column types
- Render values as chips with appropriate styling
- Reuse TaskStatusBadge for known task statuses (completed, failed, etc.)
- Use neutral gray chips for other select values
- Export statuses and isTaskStatus utility from TaskStatusBadge to avoid duplication
- Integrate SelectCell into CellFactory for 'select' column type