### PR TITLE
Pla 476 Add a new set of bots

### DIFF
--- a/packages/bots/src/bots/awellhealth/activity-to-awell-connector.ts
+++ b/packages/bots/src/bots/awellhealth/activity-to-awell-connector.ts
@@ -206,6 +206,15 @@ export async function handler(
     }
 
     task.input = [...(inputs || []), newInput]
+    // Initialize note array if it doesn't exist
+    if (!task.note) {
+      task.note = []
+    }
+    task.note.push({
+      text: 'Connector input added for Awell Care',
+      authorString: '[Awell] Connector bot',
+      time: new Date().toISOString(),
+    })
     taskChanged = true
   }
 
@@ -231,6 +240,15 @@ export async function handler(
       }
 
       task.input = [...(inputs || []), newInput]
+      // Initialize note array if it doesn't exist
+      if (!task.note) {
+        task.note = []
+      }
+      task.note.push({
+        text: 'Connector input added for Awell Hosted Pages',
+        authorString: '[Awell] Connector bot',
+        time: new Date().toISOString(),
+      })
       taskChanged = true
     }
   }

--- a/packages/bots/src/bots/awellhealth/calculated_observations/cdk-stage.ts
+++ b/packages/bots/src/bots/awellhealth/calculated_observations/cdk-stage.ts
@@ -1,0 +1,147 @@
+import type { BotEvent, MedplumClient } from '@medplum/core'
+import type { Observation, DetectedIssue } from '@medplum/fhirtypes'
+
+export async function handler(
+  medplum: MedplumClient,
+  event: BotEvent<Observation>,
+): Promise<void> {
+  console.log('CDK Stage Bot: Starting processing', {
+    observationId: event.input?.id,
+    resourceType: event.input?.resourceType,
+  })
+
+  const obs = event.input
+  const egfr = obs.valueQuantity?.value
+
+  console.log('CDK Stage Bot: Extracted eGFR value', {
+    egfr,
+    observationId: obs.id,
+    hasValueQuantity: !!obs.valueQuantity,
+    unit: obs.valueQuantity?.unit,
+  })
+
+  if (egfr !== undefined && obs.subject?.reference) {
+    const patientRef = obs.subject.reference
+    console.log(
+      'CDK Stage Bot: Processing observation with valid eGFR and patient reference',
+      {
+        egfr,
+        patientRef,
+        observationId: obs.id,
+      },
+    )
+
+    const stage =
+      egfr >= 90
+        ? 'Stage I'
+        : egfr >= 60
+          ? 'Stage II'
+          : egfr >= 45
+            ? 'Stage IIIa'
+            : egfr >= 30
+              ? 'Stage IIIb'
+              : egfr >= 15
+                ? 'Stage IV'
+                : 'Stage V'
+
+    console.log('CDK Stage Bot: Calculated CKD stage', {
+      egfr,
+      stage,
+      patientRef,
+    })
+
+    const derived: Observation = {
+      resourceType: 'Observation',
+      status: 'final',
+      code: { text: 'CKD Stage' },
+      subject: { reference: patientRef },
+      effectiveDateTime: obs.effectiveDateTime,
+      valueString: stage,
+      derivedFrom: [{ reference: `Observation/${obs.id}` }],
+    }
+
+    try {
+      const createdObservation = await medplum.createResource(derived)
+      console.log('CDK Stage Bot: Successfully created CKD stage observation', {
+        newObservationId: createdObservation.id,
+        stage,
+        patientRef,
+        sourceObservationId: obs.id,
+      })
+    } catch (error) {
+      console.error('CDK Stage Bot: Failed to create CKD stage observation', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        stage,
+        patientRef,
+        sourceObservationId: obs.id,
+      })
+      throw error
+    }
+
+    if (stage === 'Stage IV' || stage === 'Stage V') {
+      console.log(
+        'CDK Stage Bot: Creating high-severity detected issue for advanced CKD stage',
+        {
+          stage,
+          patientRef,
+          sourceObservationId: obs.id,
+        },
+      )
+
+      const issue: DetectedIssue = {
+        resourceType: 'DetectedIssue',
+        status: 'final',
+        severity: 'high',
+        code: { text: `CKD ${stage}` },
+        patient: { reference: patientRef },
+        implicated: [{ reference: `Observation/${obs.id}` }],
+        identifiedDateTime: new Date().toISOString(),
+      }
+
+      try {
+        const createdIssue = await medplum.createResource(issue)
+        console.log('CDK Stage Bot: Successfully created detected issue', {
+          issueId: createdIssue.id,
+          stage,
+          patientRef,
+          sourceObservationId: obs.id,
+        })
+      } catch (error) {
+        console.error('CDK Stage Bot: Failed to create detected issue', {
+          error: error instanceof Error ? error.message : 'Unknown error',
+          stage,
+          patientRef,
+          sourceObservationId: obs.id,
+        })
+        throw error
+      }
+    }
+  } else {
+    console.log('CDK Stage Bot: Skipping observation - missing required data', {
+      hasEgfr: egfr !== undefined,
+      hasPatientRef: !!obs.subject?.reference,
+      observationId: obs.id,
+      egfr,
+      patientRef: obs.subject?.reference,
+    })
+  }
+
+  console.log('CDK Stage Bot: Processing completed', {
+    observationId: obs.id,
+    egfr,
+    stage:
+      egfr !== undefined
+        ? egfr >= 90
+          ? 'Stage I'
+          : egfr >= 60
+            ? 'Stage II'
+            : egfr >= 45
+              ? 'Stage IIIa'
+              : egfr >= 30
+                ? 'Stage IIIb'
+                : egfr >= 15
+                  ? 'Stage IV'
+                  : 'Stage V'
+        : 'N/A',
+  })
+}

--- a/packages/bots/src/bots/awellhealth/datapoint-bot-router.ts
+++ b/packages/bots/src/bots/awellhealth/datapoint-bot-router.ts
@@ -1,5 +1,5 @@
 import type { BotEvent, MedplumClient } from '@medplum/core'
-import type { Patient, BundleEntry } from '@medplum/fhirtypes'
+import type { BundleEntry, Patient } from '@medplum/fhirtypes'
 
 // Type definition for observation details
 interface ObservationDetails {
@@ -25,8 +25,20 @@ const OBSERVATION_IDS = [
   'uaz1iQmTESPT',
   'MKNSHn3UD5sR',
   'kOHcXDHBIzUa',
+  'WIjuq76K7SBz',
+  'Ishz9pSGkJBD',
+  'DTAGURJlhN3H',
+  'gIHHenuvypiZ',
+  '9Eee2fNv0xb4',
+  'JpmWTYLWS187',
+  'JW8UzMRGqjfi',
+  'D9oD8Uxx38kG',
+  'NEo1y6hPujJa',
+  'P4RyWS8bWWLt',
+  'xsDmxTlZ0PAz',
+  'imeMqggxB59W',
 ]
-const ENCOUNTER_IDS = ['54sxFoMUSZGx', 'exs1LmSV01uN9TtKoRdHZ']
+const ENCOUNTER_IDS = ['54sxFoMUSZGx']
 
 const ENCOUNTER_DICT: Record<string, string> = {
   encounter_class: 'W9g0WAwiodltREpc4p5fw',
@@ -101,6 +113,118 @@ const OBSERVATION_DICT: Record<string, ObservationDetails> = {
     coding: { system: 'http://loinc.org', code: '29463-7', display: 'Weight' },
     category: 'laboratory',
   },
+  WIjuq76K7SBz: {
+    definition_name: 'observation_cardioSymptoms',
+    unit: 'NA',
+    display: 'Cardiovascular Symptoms',
+    coding: {
+      system: 'http://loinc.org',
+      code: 'LA33-6',
+      display: 'Cardiovascular Symptoms',
+    },
+    category: 'survey',
+  },
+  Ishz9pSGkJBD: {
+    definition_name: 'observation_dietary',
+    unit: 'NA',
+    display: 'Dietary Assessment',
+    coding: {
+      system: 'http://loinc.org',
+      code: 'LA33-6',
+      display: 'Dietary Assessment',
+    },
+    category: 'survey',
+  },
+  DTAGURJlhN3H: {
+    definition_name: 'observation_siteInfectionRisk',
+    unit: 'NA',
+    display: 'Site Infection Risk',
+    coding: {
+      system: 'http://loinc.org',
+      code: 'LA33-6',
+      display: 'Site Infection Risk',
+    },
+    category: 'survey',
+  },
+  gIHHenuvypiZ: {
+    definition_name: 'observation_swelling',
+    unit: 'NA',
+    display: 'Swelling',
+    coding: { system: 'http://loinc.org', code: 'LA33-6', display: 'Swelling' },
+    category: 'survey',
+  },
+  '9Eee2fNv0xb4': {
+    definition_name: 'observation_weightGain',
+    unit: 'lbs',
+    display: 'Weight Gain',
+    coding: {
+      system: 'http://loinc.org',
+      code: 'LA33-6',
+      display: 'Weight Gain',
+    },
+    category: 'survey',
+  },
+  JpmWTYLWS187: {
+    definition_name: 'observation_creatinine_mg_dl',
+    unit: 'mg/dL',
+    display: 'Creatinine',
+    coding: {
+      system: 'http://loinc.org',
+      code: '2160-0',
+      display: 'Creatinine',
+    },
+    category: 'laboratory',
+  },
+  JW8UzMRGqjfi: {
+    definition_name: 'observation_dbp_mmHg',
+    unit: 'mmHg',
+    display: 'Diastolic Blood Pressure',
+    coding: {
+      system: 'http://loinc.org',
+      code: '8480-6',
+      display: 'Diastolic Blood Pressure',
+    },
+    category: 'vital-signs',
+  },
+  D9oD8Uxx38kG: {
+    definition_name: 'observation_egfr_ml_min',
+    unit: 'mL/min',
+    display: 'eGFR',
+    coding: { system: 'http://loinc.org', code: '33914-3', display: 'eGFR' },
+    category: 'laboratory',
+  },
+  NEo1y6hPujJa: {
+    definition_name: 'observation_hba1c_percent',
+    unit: '%',
+    display: 'HbA1c',
+    coding: { system: 'http://loinc.org', code: '30425-0', display: 'HbA1c' },
+    category: 'laboratory',
+  },
+  P4RyWS8bWWLt: {
+    definition_name: 'observation_sbp_mmHg',
+    unit: 'mmHg',
+    display: 'Systolic Blood Pressure',
+    coding: {
+      system: 'http://loinc.org',
+      code: '8480-6',
+      display: 'Systolic Blood Pressure',
+    },
+    category: 'vital-signs',
+  },
+  xsDmxTlZ0PAz: {
+    definition_name: 'observation_sodium_mmol_l',
+    unit: 'mmol/L',
+    display: 'Sodium',
+    coding: { system: 'http://loinc.org', code: '2955-2', display: 'Sodium' },
+    category: 'laboratory',
+  },
+  imeMqggxB59W: {
+    definition_name: 'observation_weight_lbs',
+    unit: 'lbs',
+    display: 'Weight',
+    coding: { system: 'http://loinc.org', code: '29463-7', display: 'Weight' },
+    category: 'laboratory',
+  },
 }
 
 // Types for the datapoint payload
@@ -115,7 +239,7 @@ interface DataPointPayload {
     date: string
     release_id: string
   }
-  pathway: {
+  pathway?: {
     id: string
     pathway_definition_id: string
     patient_id: string
@@ -175,7 +299,7 @@ async function findPatientByIdentifier(
 }
 
 // Create or find patient
-async function findOrCreatePatient(
+async function upsertPatient(
   medplum: MedplumClient,
   patientId: string,
   patientIdentifiers: Array<{ system: string; value: string }>,
@@ -198,14 +322,17 @@ async function findOrCreatePatient(
     })),
   ]
 
-  const newPatient = (await medplum.updateResource({
-    resourceType: 'Patient',
-    identifier: identifiers,
-    active: true,
-  })) as Patient
+  const newPatient = (await medplum.upsertResource(
+    {
+      resourceType: 'Patient',
+      identifier: identifiers,
+      active: true,
+    },
+    `identifier=${patientId}`,
+  )) as Patient
 
   console.log(
-    'New patient created:',
+    'Upserted patient:',
     JSON.stringify(
       {
         originalId: patientId,
@@ -233,6 +360,7 @@ export async function handler(
         eventType: event.input.event_type,
         pathwayId: event.input.pathway_id,
         patientId: patient_id,
+        hasPathway: !!pathway,
       },
       null,
       2,
@@ -240,11 +368,27 @@ export async function handler(
   )
 
   try {
+    // Log pathway information for debugging
+    if (!pathway) {
+      console.log(
+        'Warning: Pathway object is missing from event input:',
+        JSON.stringify(
+          {
+            dataPointId: data_point.id,
+            patientId: patient_id,
+            pathwayId: event.input.pathway_id,
+          },
+          null,
+          2,
+        ),
+      )
+    }
+
     // Find or create patient
-    const patientId = await findOrCreatePatient(
+    const patientId = await upsertPatient(
       medplum,
       patient_id,
-      pathway.patient_identifiers,
+      pathway?.patient_identifiers || [],
     )
 
     // Route datapoint to appropriate bot based on data_point_definition_id
@@ -299,7 +443,7 @@ export async function handler(
             dataPointId: data_point.id,
             dataPointDefinitionId: data_point.data_point_definition_id,
             botId: BOT_ROUTER_DICT['encounter-bot'],
-            pathwayId: pathway.id,
+            pathwayId: pathway?.id || 'unknown',
           },
           null,
           2,
@@ -315,7 +459,7 @@ export async function handler(
         data_point,
         encounter_dict: ENCOUNTER_DICT,
         patient_id: patientId,
-        pathway_id: pathway.id,
+        pathway_id: pathway?.id || event.input.pathway_id,
       } as DataPointRouterPayload)
 
       console.log(

--- a/packages/bots/src/bots/awellhealth/datapoint-bot-router.ts
+++ b/packages/bots/src/bots/awellhealth/datapoint-bot-router.ts
@@ -1,0 +1,374 @@
+import type { BotEvent, MedplumClient } from '@medplum/core'
+import type { Patient, BundleEntry } from '@medplum/fhirtypes'
+
+// Type definition for observation details
+interface ObservationDetails {
+  definition_name: string
+  unit: string
+  display: string
+  coding: {
+    system: string
+    code: string
+    display: string
+  }
+  category: string
+}
+
+const BOT_ROUTER_DICT: Record<string, string> = {
+  'observation-bot': '0197e96e-9c40-77d6-80fc-f95f4fb369de',
+  'encounter-bot': '0197e9b6-79bd-776a-b7cc-0a169cdda14d',
+}
+
+const OBSERVATION_IDS = [
+  'DhPRklTreXaP',
+  'TVNF1l5qPDvu',
+  'uaz1iQmTESPT',
+  'MKNSHn3UD5sR',
+  'kOHcXDHBIzUa',
+]
+const ENCOUNTER_IDS = ['54sxFoMUSZGx', 'exs1LmSV01uN9TtKoRdHZ']
+
+const ENCOUNTER_DICT: Record<string, string> = {
+  encounter_class: 'W9g0WAwiodltREpc4p5fw',
+  encounter_datetime: 'rRiRPn5E80Rf',
+  encounter_location: 'mIR8pQtSndiPY45jU8jq8',
+  encounter_type: 'KqwuG9KONE7m',
+  encounter_location_id: 'RnaZLqW0xoQQFz63jHQ3D',
+  encounter_nurse_unit: 'xK1eYmA5lYDPmwoCxizTD',
+  encounter_nurse_unit_id: 'chgRgehKNxnVdb9WWq7px',
+  encounter_service_type: 'DoGqJkOBHO2etWGjGfQ7Y',
+}
+
+const OBSERVATION_DICT: Record<string, ObservationDetails> = {
+  DhPRklTreXaP: {
+    definition_name: 'observation_creatinine_mg_dl',
+    unit: 'mg/dL',
+    display: 'Creatinine',
+    coding: {
+      system: 'http://loinc.org',
+      code: '2160-0',
+      display: 'Creatinine',
+    },
+    category: 'laboratory',
+  },
+  TVNF1l5qPDvu: {
+    definition_name: 'observation_dbp_mmHg',
+    unit: 'mmHg',
+    display: 'Diastolic Blood Pressure',
+    coding: {
+      system: 'http://loinc.org',
+      code: '8480-6',
+      display: 'Diastolic Blood Pressure',
+    },
+    category: 'vital-signs',
+  },
+  uaz1iQmTESPT: {
+    definition_name: 'observation_egfr_ml_min',
+    unit: 'mL/min',
+    display: 'eGFR',
+    coding: { system: 'http://loinc.org', code: '33914-3', display: 'eGFR' },
+    category: 'laboratory',
+  },
+  MKNSHn3UD5sR: {
+    definition_name: 'observation_hba1c_percent',
+    unit: '%',
+    display: 'HbA1c',
+    coding: { system: 'http://loinc.org', code: '30425-0', display: 'HbA1c' },
+    category: 'laboratory',
+  },
+  kOHcXDHBIzUa: {
+    definition_name: 'observation_sbp_mmHg',
+    unit: 'mmHg',
+    display: 'Systolic Blood Pressure',
+    coding: {
+      system: 'http://loinc.org',
+      code: '8480-6',
+      display: 'Systolic Blood Pressure',
+    },
+    category: 'vital-signs',
+  },
+  FtPUGWZaBaDC: {
+    definition_name: 'observation_sodium_mmol_l',
+    unit: 'mmol/L',
+    display: 'Sodium',
+    coding: { system: 'http://loinc.org', code: '2955-2', display: 'Sodium' },
+    category: 'laboratory',
+  },
+  GlXTOIANxlMP: {
+    definition_name: 'observation_weight_lbs',
+    unit: 'lbs',
+    display: 'Weight',
+    coding: { system: 'http://loinc.org', code: '29463-7', display: 'Weight' },
+    category: 'laboratory',
+  },
+}
+
+// Types for the datapoint payload
+interface DataPointPayload {
+  data_point: {
+    id: string
+    tenant_id: string
+    data_point_definition_id: string
+    valueType: string
+    value: number | string
+    data_set_id: string
+    date: string
+    release_id: string
+  }
+  pathway: {
+    id: string
+    pathway_definition_id: string
+    patient_id: string
+    patient_identifiers: Array<{
+      system: string
+      value: string
+    }>
+    tenant_id: string
+    start_date: string
+    pathway_title: string
+  }
+  event_type: string
+  pathway_definition_id: string
+  pathway_id: string
+  patient_id: string
+}
+
+interface DataPointRouterPayload {
+  data_point: DataPointPayload['data_point']
+  observation_dict?: Record<string, ObservationDetails>
+  encounter_dict?: Record<string, string>
+  patient_id: string
+  pathway_id: string
+}
+
+// Find patient by identifier
+async function findPatientByIdentifier(
+  medplum: MedplumClient,
+  patientId: string,
+): Promise<BundleEntry<Patient> | undefined> {
+  try {
+    const searchResult = await medplum.search(
+      'Patient',
+      `identifier=${patientId}`,
+    )
+    if (searchResult.entry?.[0]?.resource?.id) {
+      console.log(
+        'Patient found in system:',
+        JSON.stringify(
+          {
+            patientId,
+            foundPatientId: searchResult.entry[0].resource.id,
+          },
+          null,
+          2,
+        ),
+      )
+      return searchResult.entry[0]
+    }
+  } catch (error) {
+    console.log(
+      'Patient not found in system:',
+      JSON.stringify({ patientId }, null, 2),
+    )
+  }
+  return undefined
+}
+
+// Create or find patient
+async function findOrCreatePatient(
+  medplum: MedplumClient,
+  patientId: string,
+  patientIdentifiers: Array<{ system: string; value: string }>,
+): Promise<string> {
+  const medplumPatient = await findPatientByIdentifier(medplum, patientId)
+
+  if (medplumPatient?.resource?.id) {
+    return medplumPatient.resource.id
+  }
+
+  // Create a new patient if not found
+  const identifiers = [
+    {
+      system: 'https://awellhealth.com/patients',
+      value: patientId,
+    },
+    ...patientIdentifiers.map((id) => ({
+      system: id.system,
+      value: id.value,
+    })),
+  ]
+
+  const newPatient = (await medplum.updateResource({
+    resourceType: 'Patient',
+    identifier: identifiers,
+    active: true,
+  })) as Patient
+
+  console.log(
+    'New patient created:',
+    JSON.stringify(
+      {
+        originalId: patientId,
+        newPatientId: newPatient.id,
+      },
+      null,
+      2,
+    ),
+  )
+
+  return newPatient.id || ''
+}
+
+export async function handler(
+  medplum: MedplumClient,
+  event: BotEvent<DataPointPayload>,
+): Promise<void> {
+  const { data_point, pathway, patient_id } = event.input
+
+  console.log(
+    'Bot started processing datapoint:',
+    JSON.stringify(
+      {
+        dataPointId: data_point.id,
+        eventType: event.input.event_type,
+        pathwayId: event.input.pathway_id,
+        patientId: patient_id,
+      },
+      null,
+      2,
+    ),
+  )
+
+  try {
+    // Find or create patient
+    const patientId = await findOrCreatePatient(
+      medplum,
+      patient_id,
+      pathway.patient_identifiers,
+    )
+
+    // Route datapoint to appropriate bot based on data_point_definition_id
+    const isObservation = OBSERVATION_IDS.includes(
+      data_point.data_point_definition_id,
+    )
+    const isEncounter = ENCOUNTER_IDS.includes(
+      data_point.data_point_definition_id,
+    )
+
+    if (isObservation) {
+      console.log(
+        'Routing to observation bot:',
+        JSON.stringify(
+          {
+            dataPointId: data_point.id,
+            dataPointDefinitionId: data_point.data_point_definition_id,
+            botId: BOT_ROUTER_DICT['observation-bot'],
+          },
+          null,
+          2,
+        ),
+      )
+
+      // Call the observation bot
+      const observationBotId = BOT_ROUTER_DICT['observation-bot']
+      if (!observationBotId) {
+        throw new Error('Observation bot ID not found in BOT_ROUTER_DICT')
+      }
+      await medplum.executeBot(observationBotId, {
+        data_point,
+        observation_dict: OBSERVATION_DICT,
+        patient_id: patientId,
+      } as DataPointRouterPayload)
+
+      console.log(
+        'Observation bot execution completed:',
+        JSON.stringify(
+          {
+            dataPointId: data_point.id,
+            observationCreated: true,
+          },
+          null,
+          2,
+        ),
+      )
+    } else if (isEncounter) {
+      console.log(
+        'Routing to encounter bot:',
+        JSON.stringify(
+          {
+            dataPointId: data_point.id,
+            dataPointDefinitionId: data_point.data_point_definition_id,
+            botId: BOT_ROUTER_DICT['encounter-bot'],
+            pathwayId: pathway.id,
+          },
+          null,
+          2,
+        ),
+      )
+
+      // Call the encounter bot
+      const encounterBotId = BOT_ROUTER_DICT['encounter-bot']
+      if (!encounterBotId) {
+        throw new Error('Encounter bot ID not found in BOT_ROUTER_DICT')
+      }
+      await medplum.executeBot(encounterBotId, {
+        data_point,
+        encounter_dict: ENCOUNTER_DICT,
+        patient_id: patientId,
+        pathway_id: pathway.id,
+      } as DataPointRouterPayload)
+
+      console.log(
+        'Encounter bot execution completed:',
+        JSON.stringify(
+          {
+            dataPointId: data_point.id,
+            encounterCreated: true,
+          },
+          null,
+          2,
+        ),
+      )
+    } else {
+      console.log(
+        'Unknown datapoint type, no routing performed:',
+        JSON.stringify(
+          {
+            dataPointId: data_point.id,
+            dataPointDefinitionId: data_point.data_point_definition_id,
+            availableObservationIds: OBSERVATION_IDS,
+            availableEncounterIds: ENCOUNTER_IDS,
+          },
+          null,
+          2,
+        ),
+      )
+    }
+
+    console.log(
+      'Bot finished processing datapoint:',
+      JSON.stringify(
+        {
+          dataPointId: data_point.id,
+          routed: isObservation || isEncounter,
+        },
+        null,
+        2,
+      ),
+    )
+  } catch (error) {
+    console.log(
+      'Error in handler:',
+      JSON.stringify(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+          dataPointId: data_point.id,
+          patientId: patient_id,
+        },
+        null,
+        2,
+      ),
+    )
+    throw error
+  }
+}

--- a/packages/bots/src/bots/awellhealth/datapoint-to-encounter.ts
+++ b/packages/bots/src/bots/awellhealth/datapoint-to-encounter.ts
@@ -1,0 +1,368 @@
+import type { BotEvent, MedplumClient } from '@medplum/core'
+import type { Encounter } from '@medplum/fhirtypes'
+
+interface DataPointRouterPayload {
+  data_point: {
+    id: string
+    tenant_id: string
+    data_point_definition_id: string
+    valueType: string
+    value: number | string
+    data_set_id: string
+    date: string
+    release_id: string
+  }
+  encounter_dict?: Record<string, string>
+  patient_id: string
+  pathway_id: string
+}
+
+// GraphQL types for fetching datapoints
+interface GraphQLError {
+  message: string
+  locations?: Array<{ line: number; column: number }>
+  path?: string[]
+}
+
+interface DataPointsResponse {
+  data: {
+    pathwayDataPoints: {
+      dataPoints: DataPoint[]
+    }
+  }
+  errors?: GraphQLError[]
+}
+
+interface DataPoint {
+  serialized_value: string
+  data_point_definition_id: string
+  valueType: string
+  date: string
+}
+
+const GET_DATA_POINT_QUERY = `
+    query GetPathwayDataPoints($pathway_id: String!, $data_point_definition_id: String) {
+    pathwayDataPoints(
+      pathway_id: $pathway_id
+      data_point_definition_id: $data_point_definition_id
+      pagination: {
+        count: 1,
+        offset: 0
+      }
+    ) {
+      dataPoints {
+        serialized_value
+        data_point_definition_id
+        valueType
+        date
+      }
+    }
+  }
+`
+// Fetch datapoints from Awell API
+async function fetchDataPoints(
+  pathwayId: string,
+  graphqlEndpoint: string,
+  apiKey: string,
+  dataPointDefinitionId?: string,
+): Promise<DataPoint[]> {
+  console.log(
+    `Fetching data points for pathway ID: ${pathwayId}${dataPointDefinitionId ? `, definition ID: ${dataPointDefinitionId}` : ''}`,
+  )
+
+  const response = await fetch(graphqlEndpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      apikey: apiKey,
+    },
+    body: JSON.stringify({
+      query: GET_DATA_POINT_QUERY,
+      variables: {
+        pathway_id: pathwayId,
+        data_point_definition_id: dataPointDefinitionId,
+      },
+      pagination: {
+        count: 1,
+        offset: 0,
+      },
+    }),
+  })
+
+  const data = (await response.json()) as DataPointsResponse
+  const dataPoints = data.data.pathwayDataPoints.dataPoints
+  console.log(`Retrieved ${dataPoints.length} data points`)
+  return dataPoints
+}
+
+// Fetch latest datapoint for a specific definition ID
+async function fetchLatestDataPoint(
+  pathwayId: string,
+  graphqlEndpoint: string,
+  apiKey: string,
+  dataPointDefinitionId: string,
+): Promise<DataPoint | null> {
+  const dataPoints = await fetchDataPoints(
+    pathwayId,
+    graphqlEndpoint,
+    apiKey,
+    dataPointDefinitionId,
+  )
+  return dataPoints.length > 0 && dataPoints[0] ? dataPoints[0] : null
+}
+
+// Fetch all encounter-related datapoints
+async function fetchEncounterDataPoints(
+  pathwayId: string,
+  graphqlEndpoint: string,
+  apiKey: string,
+  encounter_dict: Record<string, string>,
+): Promise<DataPoint[]> {
+  const encounterDataPoints: DataPoint[] = []
+
+  // Fetch latest datapoint for each encounter field
+  for (const [fieldName, definitionId] of Object.entries(encounter_dict)) {
+    console.log(
+      `Fetching latest datapoint for ${fieldName} (definition ID: ${definitionId})`,
+    )
+    const dataPoint = await fetchLatestDataPoint(
+      pathwayId,
+      graphqlEndpoint,
+      apiKey,
+      definitionId,
+    )
+    if (dataPoint) {
+      encounterDataPoints.push(dataPoint)
+    }
+  }
+
+  console.log(
+    `Retrieved ${encounterDataPoints.length} encounter-related datapoints`,
+  )
+  return encounterDataPoints
+}
+
+// Create encounter from datapoints
+function createEncounterFromDataPoints(
+  dataPoints: DataPoint[],
+  patientId: string,
+  encounterId: string,
+  encounter_dict: Record<string, string>,
+): Encounter {
+  // Create a map of field values from datapoints
+  const fieldValues = new Map<string, string>()
+
+  for (const dataPoint of dataPoints) {
+    // Find the field name by looking up the definition ID in the reversed dictionary
+    const fieldName = Object.keys(encounter_dict).find(
+      (key) => encounter_dict[key] === dataPoint.data_point_definition_id,
+    )
+    if (fieldName) {
+      fieldValues.set(fieldName, dataPoint.serialized_value)
+    }
+  }
+
+  const encounter: Encounter = {
+    resourceType: 'Encounter',
+    status: 'finished',
+    class: {
+      system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+      code: fieldValues.get('encounter_class') || 'EMR',
+      display: fieldValues.get('encounter_class') || 'emergency',
+    },
+    subject: {
+      reference: `Patient/${patientId}`,
+    },
+    identifier: [
+      {
+        system: 'https://waypointhcs.com/encounters',
+        value: encounterId,
+      },
+    ],
+  }
+
+  // Set period if encounter_datetime is available
+  const encounterDateTime = fieldValues.get('encounter_datetime')
+  if (encounterDateTime) {
+    const encounterDate = new Date(encounterDateTime)
+    encounter.period = {
+      start: encounterDate.toISOString(),
+    }
+  }
+
+  // Set type if encounter_type is available
+  const encounterType = fieldValues.get('encounter_type')
+  if (encounterType) {
+    encounter.type = [
+      {
+        coding: [
+          {
+            system: 'https://awellhealth.com/fhir/CodeSystem/encounter-type',
+            code: encounterType,
+            display: encounterType,
+          },
+        ],
+        text: encounterType,
+      },
+    ]
+  }
+
+  // Set location if encounter_location is available
+  const encounterLocation = fieldValues.get('encounter_location')
+  if (encounterLocation) {
+    encounter.location = [
+      {
+        location: {
+          reference: `Location/${fieldValues.get('encounter_location_id') || 'unknown'}`,
+          display: encounterLocation,
+        },
+      },
+    ]
+  }
+
+  // Add extensions for additional encounter data
+  const extensions = []
+
+  const encounterNurseUnit = fieldValues.get('encounter_nurse_unit')
+  if (encounterNurseUnit) {
+    extensions.push({
+      url: 'https://awellhealth.com/fhir/StructureDefinition/encounter-nurse-unit',
+      valueString: encounterNurseUnit,
+    })
+  }
+
+  const encounterNurseUnitId = fieldValues.get('encounter_nurse_unit_id')
+  if (encounterNurseUnitId) {
+    extensions.push({
+      url: 'https://awellhealth.com/fhir/StructureDefinition/encounter-nurse-unit-id',
+      valueString: encounterNurseUnitId,
+    })
+  }
+
+  const encounterServiceType = fieldValues.get('encounter_service_type')
+  if (encounterServiceType) {
+    extensions.push({
+      url: 'https://awellhealth.com/fhir/StructureDefinition/encounter-service-type',
+      valueString: encounterServiceType,
+    })
+  }
+
+  if (extensions.length > 0) {
+    encounter.extension = extensions
+  }
+
+  return encounter
+}
+
+export async function handler(
+  medplum: MedplumClient,
+  event: BotEvent<DataPointRouterPayload>,
+): Promise<void> {
+  const { data_point, patient_id, pathway_id, encounter_dict } = event.input
+
+  // Check if we have the required secrets for Awell API
+  if (!event.secrets.AWELL_API_URL || !event.secrets.AWELL_API_KEY) {
+    console.log(
+      'AWELL_API_URL or AWELL_API_KEY is not set, skipping encounter creation',
+    )
+    return
+  }
+
+  const graphqlEndpoint = event.secrets.AWELL_API_URL.valueString || ''
+  const apiKey = event.secrets.AWELL_API_KEY.valueString || ''
+
+  console.log(
+    'Bot started processing datapoint:',
+    JSON.stringify(
+      {
+        dataPointId: data_point.id,
+        patientId: patient_id,
+      },
+      null,
+      2,
+    ),
+  )
+
+  try {
+    if (!encounter_dict) {
+      throw new Error('Encounter dictionary is required but not provided')
+    }
+
+    console.log(
+      'Encounter datapoint detected, creating encounter:',
+      JSON.stringify(
+        {
+          dataPointId: data_point.id,
+          encounterId: data_point.value,
+          patientId: patient_id,
+        },
+        null,
+        2,
+      ),
+    )
+
+    // Fetch all encounter-related datapoints
+    const encounterDataPoints = await fetchEncounterDataPoints(
+      pathway_id,
+      graphqlEndpoint,
+      apiKey,
+      encounter_dict,
+    )
+
+    // Create encounter from datapoints
+    const encounter = createEncounterFromDataPoints(
+      encounterDataPoints,
+      patient_id,
+      data_point.value.toString(),
+      encounter_dict,
+    )
+
+    // Save encounter to Medplum
+    const resultEncounter = await medplum.createResource(encounter)
+
+    console.log(
+      'Encounter created successfully:',
+      JSON.stringify(
+        {
+          encounterId: resultEncounter.id,
+          dataPointId: data_point.id,
+          patientId: patient_id,
+          pathwayId: pathway_id,
+          encounterValue: data_point.value,
+          encounterStatus: encounter.status,
+          encounterClass: encounter.class?.display,
+          encounterType: encounter.type?.[0]?.text,
+        },
+        null,
+        2,
+      ),
+    )
+
+    console.log(
+      'Bot finished processing encounter datapoint:',
+      JSON.stringify(
+        {
+          dataPointId: data_point.id,
+          encounterCreated: true,
+          encounterId: resultEncounter.id,
+        },
+        null,
+        2,
+      ),
+    )
+  } catch (error) {
+    console.log(
+      'Error in handler:',
+      JSON.stringify(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+          dataPointId: data_point.id,
+          patientId: patient_id,
+        },
+        null,
+        2,
+      ),
+    )
+    throw error
+  }
+}

--- a/packages/bots/src/bots/awellhealth/datapoint-to-observation.ts
+++ b/packages/bots/src/bots/awellhealth/datapoint-to-observation.ts
@@ -1,0 +1,184 @@
+import type { BotEvent, MedplumClient } from '@medplum/core'
+import type { Observation } from '@medplum/fhirtypes'
+
+// Type definition for observation details
+interface ObservationDetails {
+  definition_name: string
+  unit: string
+  display: string
+  coding: {
+    system: string
+    code: string
+    display: string
+  }
+  category: string
+}
+
+interface DataPointRouterPayload {
+  data_point: {
+    id: string
+    tenant_id: string
+    data_point_definition_id: string
+    valueType: string
+    value: number | string
+    data_set_id: string
+    date: string
+    release_id: string
+  }
+  observation_dict: Record<string, ObservationDetails>
+  patient_id: string
+}
+
+// Get observation details by ID
+function getObservationDetails(
+  observationId: string,
+  observation_dict: Record<string, ObservationDetails>,
+): ObservationDetails | undefined {
+  return observation_dict[observationId]
+}
+// Create observation from datapoint
+function createObservationFromDataPoint(
+  dataPoint: DataPointRouterPayload['data_point'],
+  patientId: string,
+  observation_dict: Record<string, ObservationDetails>,
+): Observation {
+  const observationDetails = getObservationDetails(
+    dataPoint.data_point_definition_id,
+    observation_dict,
+  )
+
+  if (!observationDetails) {
+    throw new Error(
+      `Unknown observation type for ID: ${dataPoint.data_point_definition_id}`,
+    )
+  }
+
+  const observation: Observation = {
+    resourceType: 'Observation',
+    status: 'final',
+    category: [
+      {
+        coding: [
+          {
+            system:
+              'http://terminology.hl7.org/CodeSystem/observation-category',
+            code: observationDetails.category,
+            display:
+              observationDetails.category === 'vital-signs'
+                ? 'Vital Signs'
+                : 'Laboratory',
+          },
+        ],
+      },
+    ],
+    code: {
+      coding: [observationDetails.coding],
+      text: observationDetails.display,
+    },
+    subject: {
+      reference: `Patient/${patientId}`,
+    },
+    effectiveDateTime: dataPoint.date,
+    issued: new Date().toISOString(),
+    identifier: [
+      {
+        system: 'https://awellhealth.com/datapoints',
+        value: dataPoint.id,
+      },
+    ],
+  }
+
+  // Set the value based on the valueType
+  if (dataPoint.valueType === 'number' && typeof dataPoint.value === 'number') {
+    observation.valueQuantity = {
+      value: dataPoint.value,
+      unit: observationDetails.unit,
+    }
+  } else if (
+    dataPoint.valueType === 'string' ||
+    typeof dataPoint.value === 'string'
+  ) {
+    observation.valueString = dataPoint.value.toString()
+  } else {
+    // Fallback to string representation
+    observation.valueString = dataPoint.value.toString()
+  }
+
+  return observation
+}
+
+export async function handler(
+  medplum: MedplumClient,
+  event: BotEvent<DataPointRouterPayload>,
+): Promise<void> {
+  const { data_point, patient_id, observation_dict } = event.input
+
+  console.log(
+    'Bot started processing datapoint:',
+    JSON.stringify(
+      {
+        dataPointId: data_point.id,
+        patientId: patient_id,
+      },
+      null,
+      2,
+    ),
+  )
+
+  try {
+    // Create observation from datapoint
+    const observation = createObservationFromDataPoint(
+      data_point,
+      patient_id,
+      observation_dict,
+    )
+
+    // Save observation to Medplum
+    const resultObservation = await medplum.createResource(observation)
+
+    console.log(
+      'Observation created successfully:',
+      JSON.stringify(
+        {
+          observationId: resultObservation.id,
+          dataPointId: data_point.id,
+          patientId: patient_id,
+          observationType: getObservationDetails(
+            data_point.data_point_definition_id,
+            observation_dict,
+          )?.display,
+          value: data_point.value,
+          effectiveDate: data_point.date,
+        },
+        null,
+        2,
+      ),
+    )
+
+    console.log(
+      'Bot finished processing datapoint:',
+      JSON.stringify(
+        {
+          dataPointId: data_point.id,
+          observationCreated: true,
+        },
+        null,
+        2,
+      ),
+    )
+  } catch (error) {
+    console.log(
+      'Error in handler:',
+      JSON.stringify(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+          dataPointId: data_point.id,
+          patientId: patient_id,
+        },
+        null,
+        2,
+      ),
+    )
+    throw error
+  }
+}

--- a/packages/bots/src/bots/awellhealth/elantion-connectors.ts
+++ b/packages/bots/src/bots/awellhealth/elantion-connectors.ts
@@ -1,0 +1,174 @@
+import type { BotEvent, MedplumClient } from '@medplum/core'
+import type {
+  Task,
+  TaskInput,
+  Patient,
+  DocumentReference,
+} from '@medplum/fhirtypes'
+
+function hasConnectorInput(
+  inputs: TaskInput[] | undefined,
+  connectorCode: string,
+): boolean {
+  if (!inputs) return false
+  return inputs.some((input) =>
+    input.type?.coding?.some(
+      (coding) =>
+        coding.system === 'http://awellhealth.com/fhir/connector-type' &&
+        coding.code === connectorCode,
+    ),
+  )
+}
+
+async function getTaskPatient(
+  medplum: MedplumClient,
+  task: Task,
+): Promise<Patient | null> {
+  if (!task.for?.reference) {
+    console.log('Task has no patient reference')
+    return null
+  }
+
+  try {
+    const patient = await medplum.readReference(task.for)
+    return patient as Patient
+  } catch (error) {
+    console.log('Failed to fetch patient:', error)
+    return null
+  }
+}
+
+function findElationIdentifier(patient: Patient): string | null {
+  if (!patient.identifier) return null
+
+  // Look for Elation identifier in patient identifiers
+  const elationIdentifier = patient.identifier.find((identifier) =>
+    identifier.system?.includes('elationhealth'),
+  )
+
+  return elationIdentifier?.value || null
+}
+
+export async function handler(
+  medplum: MedplumClient,
+  event: BotEvent<Task>,
+): Promise<void> {
+  const task = event.input as Task
+  const inputs = task?.input as TaskInput[] | undefined
+
+  // Get task patient
+  const patient = await getTaskPatient(medplum, task)
+  if (!patient) {
+    console.log('Could not retrieve patient for task')
+    return
+  }
+
+  if (hasConnectorInput(inputs, 'elation')) {
+    console.log('Connector input already exists for Elation')
+    return
+  }
+
+  // Check if there is an Elation identifier for that patient
+  const elationPatientId = findElationIdentifier(patient)
+  if (!elationPatientId) {
+    console.log('No Elation identifier found for patient')
+    return
+  }
+
+  // Use environment variable for connector URL, fallback to sandbox
+  const elationBaseUrl =
+    event.secrets.ELATION_BASE_URL?.valueString ||
+    'https://sandbox.elationemr.com'
+  const connectorUrl = `${elationBaseUrl}/patient/${elationPatientId}`
+
+  const newInput: TaskInput = {
+    type: {
+      coding: [
+        {
+          system: 'http://awellhealth.com/fhir/connector-type',
+          code: 'elation',
+          display: 'Elation',
+        },
+      ],
+    },
+    valueUrl: connectorUrl,
+  }
+
+  task.input = [...(inputs || []), newInput]
+  // Initialize note array if it doesn't exist
+  if (!task.note) {
+    task.note = []
+  }
+  task.note.push({
+    text: 'Connector input added for Elation',
+    authorString: '[Awell] Connector bot',
+    time: new Date().toISOString(),
+  })
+
+  console.log('Updating task with new Elation inputs')
+  await medplum.updateResource(task)
+
+  // Create a DocumentReference for the patient
+  try {
+    const documentReference: DocumentReference = {
+      resourceType: 'DocumentReference',
+      status: 'current',
+      type: {
+        coding: [
+          {
+            system: 'http://loinc.org',
+            code: '11506-3',
+            display: 'Progress note',
+          },
+        ],
+        text: 'Elation Patient Data',
+      },
+      category: [
+        {
+          coding: [
+            {
+              system:
+                'http://terminology.hl7.org/CodeSystem/document-classcodes',
+              code: 'CLINNOT',
+              display: 'Clinical Note',
+            },
+          ],
+        },
+      ],
+      subject: {
+        reference: `Patient/${patient.id}`,
+        display: patient.name?.[0]?.text || 'Unknown',
+      },
+      date: new Date().toISOString(),
+      content: [
+        {
+          attachment: {
+            contentType: 'text/html',
+            url: connectorUrl,
+            title: 'Elation Patient Data',
+          },
+        },
+      ],
+      context: {
+        encounter: task.encounter ? [task.encounter] : undefined,
+        related: task.basedOn ? task.basedOn : undefined,
+      },
+      description: `Elation patient data for patient ${elationPatientId}`,
+    }
+
+    const createdDocumentReference =
+      await medplum.createResource(documentReference)
+    console.log('Successfully created DocumentReference for patient', {
+      documentReferenceId: createdDocumentReference.id,
+      patientId: patient.id,
+      elationPatientId,
+    })
+  } catch (error) {
+    console.error('Failed to create DocumentReference for patient', {
+      error: error instanceof Error ? error.message : 'Unknown error',
+      patientId: patient.id,
+      elationPatientId,
+    })
+    // Don't throw error to avoid failing the entire task update
+  }
+}

--- a/packages/bots/src/bots/awellhealth/enrich-with-awell-datapoints.ts
+++ b/packages/bots/src/bots/awellhealth/enrich-with-awell-datapoints.ts
@@ -253,13 +253,31 @@ async function updateTaskWithExtensions(
     task.extension = []
   }
 
+  // Initialize note array if it doesn't exist
+  if (!task.note) {
+    task.note = []
+  }
+
   try {
     console.log(
       `Adding ${nonJsonExtensions.length} non-JSON data point extensions to task`,
     )
     task.extension.push(...nonJsonExtensions)
+
+    // Add a note about the data point enrichment
+    const totalDataPoints = nonJsonExtensions.length + jsonExtensions.length
+    const noteText = `Enriched with ${totalDataPoints} Awell data points`
+
+    task.note.push({
+      text: noteText,
+      authorString: '[Awell] Data enrichment bot',
+      time: new Date().toISOString(),
+    })
+
     await medplum.updateResource(task)
-    console.log('Successfully updated task with non-JSON data point extensions')
+    console.log(
+      'Successfully updated task with non-JSON data point extensions and note',
+    )
   } catch (error) {
     console.log(
       'ERROR: Error updating task with data point extensions:',


### PR DESCRIPTION
Create bots:
- A datapoint bot router that will have customer specific mappings and data
- A datapoint to Observation bot
- A datapoint to Encounter bot
- Elation connector bot
- Improve existing bots to ensure we log what happens on a task level