### PR TITLE
Improve Manual Track Activation UX

### DIFF
--- a/apps/app/src/components/ManualTrackButton.tsx
+++ b/apps/app/src/components/ManualTrackButton.tsx
@@ -43,6 +43,11 @@ export function ManualTrackButton({ patientId }: ManualTrackButtonProps) {
 
   // Handle track activation
   const handleTrackSelection = async (track: TrackWithPathway) => {
+    // Don't proceed if pathway is not active
+    if (!track.isPathwayActive) {
+      return
+    }
+
     setIsOptimisticUpdate(true)
     setIsDropdownOpen(false)
 
@@ -114,18 +119,32 @@ export function ManualTrackButton({ patientId }: ManualTrackButtonProps) {
         <div className="absolute top-full right-0 mt-1 w-64 bg-white border border-gray-200 rounded-lg shadow-lg z-50">
           <div className="p-3">
             <div className="space-y-1">
-              {availableTracks.map((track) => (
-                <button
-                  key={`${track.id}-${track.pathwayId}`}
-                  type="button"
-                  onClick={() => handleTrackSelection(track)}
-                  disabled={isLoading}
-                  className="w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 rounded-md transition-colors flex items-center gap-2 disabled:opacity-50"
-                >
-                  <Plus className="h-3 w-3 text-gray-500" />
-                  <span>{track.title}</span>
-                </button>
-              ))}
+              {availableTracks.map((track) => {
+                const isTrackDisabled = !track.isPathwayActive || isLoading
+                const trackTooltip = !track.isPathwayActive
+                  ? `Care flow is ${track.pathwayStatus} - track unavailable`
+                  : undefined
+
+                return (
+                  <button
+                    key={`${track.id}-${track.pathwayId}`}
+                    type="button"
+                    onClick={() => handleTrackSelection(track)}
+                    disabled={isTrackDisabled}
+                    title={trackTooltip}
+                    className={`w-full px-3 py-2 text-left text-sm rounded-md transition-colors flex items-center gap-2 ${
+                      isTrackDisabled
+                        ? 'text-gray-400 cursor-not-allowed bg-gray-50'
+                        : 'text-gray-700 hover:bg-gray-50 cursor-pointer'
+                    }`}
+                  >
+                    <Plus
+                      className={`h-3 w-3 ${isTrackDisabled ? 'text-gray-300' : 'text-gray-500'}`}
+                    />
+                    <span>{track.title}</span>
+                  </button>
+                )
+              })}
             </div>
           </div>
         </div>

--- a/apps/app/src/components/ManualTrackButton.tsx
+++ b/apps/app/src/components/ManualTrackButton.tsx
@@ -34,30 +34,35 @@ export function ManualTrackButton({ patientId }: ManualTrackButtonProps) {
   // Show toast error when tracks fail to load
   useEffect(() => {
     if (tracksError) {
-      showError('Failed to load available tracks')
+      showError('Failed to load available tracks', undefined, {
+        duration: 5000,
+        dismissible: false,
+      })
     }
   }, [tracksError, showError])
 
   // Handle track activation
   const handleTrackSelection = async (track: TrackWithPathway) => {
-    try {
-      setIsOptimisticUpdate(true)
-      setIsDropdownOpen(false)
+    setIsOptimisticUpdate(true)
+    setIsDropdownOpen(false)
 
-      const success = await activateTrack(track.id, track.pathwayId)
+    const success = await activateTrack(track.id, track.pathwayId)
 
-      if (success) {
-        showSuccess(`Successfully activated track: ${track.title}`)
-      } else {
-        showError('Failed to activate track')
-      }
-    } catch (error) {
-      showError(
-        `Failed to activate track: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      )
-    } finally {
-      setIsOptimisticUpdate(false)
+    if (success) {
+      showSuccess(`Successfully activated track: ${track.title}`, undefined, {
+        duration: 4000,
+        dismissible: false,
+      })
+    } else {
+      // Use the actual GraphQL error message if available
+      const errorMessage = activationError || 'Failed to activate track'
+      showError(errorMessage, undefined, {
+        duration: 5000,
+        dismissible: false,
+      })
     }
+
+    setIsOptimisticUpdate(false)
   }
 
   // Don't render if no Awell care flow context

--- a/apps/app/src/components/ToastContainer.tsx
+++ b/apps/app/src/components/ToastContainer.tsx
@@ -37,7 +37,8 @@ export function ToastContainer({
   const visibleToasts = toasts.slice(-maxToasts)
 
   const getPositionStyles = (position: ToastPosition) => {
-    const baseStyles = 'fixed z-50 flex flex-col gap-2 p-4 pointer-events-none'
+    const baseStyles =
+      'fixed z-[9999] flex flex-col gap-2 p-4 pointer-events-none'
 
     switch (position) {
       case 'top-right':

--- a/apps/app/src/graphql/generated-types.ts
+++ b/apps/app/src/graphql/generated-types.ts
@@ -19,9 +19,19 @@ export interface AdHocTracksByPathway {
   tracks: Track[]
 }
 
+// Pathway types
+export interface Pathway {
+  status: string
+}
+
+export interface PathwayResponse {
+  pathway: Pathway
+}
+
 // Query types
 export interface GetAdHocTracksQuery {
   adHocTracksByPathway: AdHocTracksByPathway
+  pathway: PathwayResponse
 }
 
 export interface GetAdHocTracksQueryVariables {

--- a/apps/app/src/graphql/queries.ts
+++ b/apps/app/src/graphql/queries.ts
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 
 /**
- * Query to get available ad hoc tracks for a specific pathway
+ * Query to get available ad hoc tracks for a specific pathway and pathway status
  */
 export const GET_AD_HOC_TRACKS = gql`
   query GetAdHocTracks($pathway_id: String!) {
@@ -9,6 +9,11 @@ export const GET_AD_HOC_TRACKS = gql`
       tracks {
         id
         title
+      }
+    }
+    pathway(id: $pathway_id) {
+      pathway {
+        status
       }
     }
   }

--- a/apps/app/src/hooks/use-manual-track-activation.ts
+++ b/apps/app/src/hooks/use-manual-track-activation.ts
@@ -1,4 +1,4 @@
-import { useLazyQuery, useMutation } from '@apollo/client'
+import { useLazyQuery, useMutation, ApolloError } from '@apollo/client'
 import { useMemo, useCallback, useEffect, useState } from 'react'
 import { useMedplumStore } from './use-medplum-store'
 import { extractUniquePathwayIds } from '@/lib/fhir-extensions'
@@ -31,11 +31,41 @@ export interface UseManualTrackActivationResult {
   // Track activation
   activateTrack: (trackId: string, pathwayId: string) => Promise<boolean>
   isActivatingTrack: boolean
-  activationError: Error | null
+  activationError: string | null
 
   // Care flow context
   careFlowIds: string[]
   hasAwellCareFlowContext: boolean
+}
+
+// Helper function to extract error message from ApolloError
+const extractErrorMessage = (error: ApolloError): string => {
+  // Try to get custom message from GraphQL error extensions
+  if (error.graphQLErrors && error.graphQLErrors.length > 0) {
+    const graphQLError = error.graphQLErrors[0]
+
+    // Check for custom message in extensions
+    const data = graphQLError.extensions?.data as
+      | Record<string, unknown>
+      | undefined
+    const customMessage = data?.customMessage
+    if (typeof customMessage === 'string') {
+      return customMessage
+    }
+
+    // Fall back to the standard message
+    if (graphQLError.message) {
+      return graphQLError.message
+    }
+  }
+
+  // Check for network errors
+  if (error.networkError?.message) {
+    return error.networkError.message
+  }
+
+  // Fall back to generic error message or the error's message property
+  return error.message || 'Failed to activate track'
 }
 
 /**
@@ -50,6 +80,10 @@ export function useManualTrackActivation(
   const [allTracks, setAllTracks] = useState<TrackWithPathway[]>([])
   const [isLoadingTracks, setIsLoadingTracks] = useState(false)
   const [tracksError, setTracksError] = useState<Error | null>(null)
+
+  // Local state for track activation
+  const [isActivatingTrack, setIsActivatingTrack] = useState(false)
+  const [activationError, setActivationError] = useState<string | null>(null)
 
   // Get patient tasks and extract care flow IDs
   const patientTasks = useMemo(() => {
@@ -138,11 +172,11 @@ export function useManualTrackActivation(
     }
   }, [careFlowIds, fetchTracks])
 
-  // Mutation for track activation
-  const [
-    addTrackMutation,
-    { loading: isActivatingTrack, error: activationError },
-  ] = useMutation<AddTrackMutation, AddTrackMutationVariables>(ADD_TRACK, {
+  // Mutation for track activation - only get the mutation function
+  const [addTrackMutation] = useMutation<
+    AddTrackMutation,
+    AddTrackMutationVariables
+  >(ADD_TRACK, {
     errorPolicy: 'all',
   })
 
@@ -156,6 +190,9 @@ export function useManualTrackActivation(
   // Track activation function - now requires both track ID and pathway ID
   const activateTrack = useCallback(
     async (trackId: string, pathwayId: string): Promise<boolean> => {
+      setIsActivatingTrack(true)
+      setActivationError(null)
+
       try {
         const input: AddTrackInput = {
           pathway_id: pathwayId,
@@ -166,10 +203,29 @@ export function useManualTrackActivation(
           variables: { input },
         })
 
+        // Check for GraphQL errors in the result
+        if (result.errors && result.errors.length > 0) {
+          const apolloError = new ApolloError({
+            graphQLErrors: result.errors,
+          })
+          const errorMessage = extractErrorMessage(apolloError)
+          setActivationError(errorMessage)
+          setIsActivatingTrack(false)
+          return false
+        }
+
+        setIsActivatingTrack(false)
         return result.data?.addTrack?.success || false
       } catch (error) {
         console.error('Failed to activate track:', error)
-        throw error
+        if (error instanceof ApolloError) {
+          const errorMessage = extractErrorMessage(error)
+          setActivationError(errorMessage)
+        } else {
+          setActivationError('Failed to activate track')
+        }
+        setIsActivatingTrack(false)
+        return false
       }
     },
     [addTrackMutation],
@@ -185,7 +241,7 @@ export function useManualTrackActivation(
     // Track activation
     activateTrack,
     isActivatingTrack,
-    activationError: activationError || null,
+    activationError,
 
     // Care flow context
     careFlowIds,

--- a/apps/app/src/hooks/use-manual-track-activation.ts
+++ b/apps/app/src/hooks/use-manual-track-activation.ts
@@ -19,6 +19,8 @@ export interface UseManualTrackActivationOptions {
 // Extended track interface that includes pathway information
 export interface TrackWithPathway extends Track {
   pathwayId: string
+  pathwayStatus: string
+  isPathwayActive: boolean
 }
 
 export interface UseManualTrackActivationResult {
@@ -127,11 +129,17 @@ export function useManualTrackActivation(
               variables: { pathway_id: pathwayId },
             })
             const tracks = result.data?.adHocTracksByPathway?.tracks || []
-            // Associate each track with its pathway ID
+            const pathwayStatus =
+              result.data?.pathway?.pathway?.status || 'unknown'
+            const isPathwayActive = pathwayStatus === 'active'
+
+            // Associate each track with its pathway ID and status
             return tracks.map(
               (track: Track): TrackWithPathway => ({
                 ...track,
                 pathwayId,
+                pathwayStatus,
+                isPathwayActive,
               }),
             )
           } catch (error) {


### PR DESCRIPTION
This PR enhances the manual track activation feature with two key improvements:

**Success and Error Messaging (PLA-554)**
- Improved success and error toast messaging for track activation
- Enhanced error handling and user feedback

**Non-Active Care Flow Handling (PLA-555)**  
- Added pathway status checking to disable tracks for non-active care flows
- Enhanced GraphQL query to include pathway status information
- Added visual indicators for disabled track options with tooltips

These changes provide clearer user feedback and prevent activation of tracks from inactive care flows, improving the overall user experience.