### PR TITLE
fix(PLA-584): resolve app crash and improve array access safety throughout codebase

### DIFF
--- a/.cursor/rules/three-step-issue-resolution.mdc
+++ b/.cursor/rules/three-step-issue-resolution.mdc
@@ -1,0 +1,33 @@
+---
+description: When you are asked to solve a bug or troubleshoot an issue.
+alwaysApply: false
+---
+# Issue Resolution Process: Three-Step Validation
+
+When working on issues, bugs, or feature requests, follow this structured three-step process with mandatory validation at each stage:
+
+## ❌ DO NOT:
+- Jump directly to implementing solutions without proper diagnosis
+- Move between phases without explicit user approval
+- Skip the review phase after implementation
+- Combine multiple phases into a single response
+- Assume the first identified cause is the root cause
+
+## ✅ DO:
+- **DIAGNOSE**: Analyze symptoms thoroughly and identify true root causes
+- **IMPLEMENT**: Design and apply comprehensive solutions to root causes
+- **REVIEW**: Assess code quality, readability, maintainability, and reuse opportunities
+- Wait for explicit user validation before proceeding to the next phase
+- Search for similar patterns that may need the same fix
+- Document key findings at each stage
+
+## Why Three-Step Validation:
+- Prevents rushed solutions that address symptoms rather than root causes
+- Ensures thorough analysis before making code changes
+- Allows for course correction at each stage based on user feedback
+- Promotes higher quality solutions through structured review
+- Reduces the risk of incomplete or poorly implemented fixes
+- Maintains focus on long-term codebase health
+
+## Phase Completion:
+Each phase must end with presenting findings to the user and asking "Ready to proceed to [next phase]?" before continuing. Never auto-advance between phases.

--- a/apps/app/next.config.ts
+++ b/apps/app/next.config.ts
@@ -9,6 +9,8 @@ const nextConfig: NextConfig = {
       bodySizeLimit: '15mb',
     },
   },
+  // Enable source maps for better error debugging in production
+  productionBrowserSourceMaps: true,
   images: {
     remotePatterns: [
       {
@@ -23,7 +25,7 @@ const nextConfig: NextConfig = {
       },
     ],
   },
-  reactProductionProfiling: true
+  reactProductionProfiling: true,
 }
 
 export default nextConfig

--- a/apps/app/src/app/panel/[panel]/components/ModalDetails/TaskDetails/ConnectorsSection.tsx
+++ b/apps/app/src/app/panel/[panel]/components/ModalDetails/TaskDetails/ConnectorsSection.tsx
@@ -1,5 +1,10 @@
 import type { WorklistTask } from '@/lib/fhir-to-table-data'
 import { useEffect, useState } from 'react'
+import {
+  getFirstCodingDisplay,
+  getFirstCodingCode,
+  getFirstCodingSystem,
+} from '@/lib/fhir-utils'
 
 interface ConnectorsSectionProps {
   task: WorklistTask
@@ -21,13 +26,13 @@ const ConnectorsSection = ({
         ?.filter(
           // biome-ignore lint/suspicious/noExplicitAny: Not sure if we have a better type
           (input: any) =>
-            input.type?.coding?.[0]?.system ===
+            getFirstCodingSystem(input.type) ===
             'http://awellhealth.com/fhir/connector-type',
         )
         // biome-ignore lint/suspicious/noExplicitAny: Not sure if we have a better type
         .map((input: any) => ({
-          name: input.type.coding[0].display,
-          code: input.type.coding[0].code,
+          name: getFirstCodingDisplay(input.type),
+          code: getFirstCodingCode(input.type),
           url: input.valueUrl,
         }))
         .filter((connector: { code: string; url: string }) => {

--- a/apps/app/src/app/panel/[panel]/components/ModalDetails/TaskDetails/TaskDetails.tsx
+++ b/apps/app/src/app/panel/[panel]/components/ModalDetails/TaskDetails/TaskDetails.tsx
@@ -11,7 +11,7 @@ interface TaskDetailsProps {
 
 const TaskDetails = ({ task }: TaskDetailsProps) => {
   const VIEWS = ['content', 'ahp', 'notes']
-  const AHP_URL = task.input[0]?.valueUrl
+  const AHP_URL = task.input?.[0]?.valueUrl
 
   return (
     <>

--- a/apps/app/src/lib/fhir-utils.test.ts
+++ b/apps/app/src/lib/fhir-utils.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getFirstCodingDisplay,
+  getFirstCodingCode,
+  getFirstCodingSystem,
+  getFirstCoding,
+  safeArrayFirst,
+} from './fhir-utils'
+import type { CodeableConcept, Coding } from '@medplum/fhirtypes'
+
+describe('fhir-utils', () => {
+  describe('getFirstCodingDisplay', () => {
+    it('should return display from first coding', () => {
+      const codeableConcept: CodeableConcept = {
+        coding: [
+          { display: 'First Display', code: 'first' },
+          { display: 'Second Display', code: 'second' },
+        ],
+      }
+
+      expect(getFirstCodingDisplay(codeableConcept)).toBe('First Display')
+    })
+
+    it('should return fallback when no coding', () => {
+      const codeableConcept: CodeableConcept = {}
+
+      expect(getFirstCodingDisplay(codeableConcept, 'Custom Fallback')).toBe(
+        'Custom Fallback',
+      )
+    })
+
+    it('should return fallback when coding array is empty', () => {
+      const codeableConcept: CodeableConcept = { coding: [] }
+
+      expect(getFirstCodingDisplay(codeableConcept)).toBe('Unknown')
+    })
+
+    it('should return fallback when display is undefined', () => {
+      const codeableConcept: CodeableConcept = {
+        coding: [{ code: 'test' }],
+      }
+
+      expect(getFirstCodingDisplay(codeableConcept)).toBe('Unknown')
+    })
+
+    it('should handle undefined input', () => {
+      expect(getFirstCodingDisplay(undefined)).toBe('Unknown')
+    })
+  })
+
+  describe('getFirstCodingCode', () => {
+    it('should return code from first coding', () => {
+      const codeableConcept: CodeableConcept = {
+        coding: [
+          { code: 'FIRST', display: 'First' },
+          { code: 'SECOND', display: 'Second' },
+        ],
+      }
+
+      expect(getFirstCodingCode(codeableConcept)).toBe('FIRST')
+    })
+
+    it('should return empty string fallback by default', () => {
+      const codeableConcept: CodeableConcept = {}
+
+      expect(getFirstCodingCode(codeableConcept)).toBe('')
+    })
+
+    it('should return custom fallback', () => {
+      const codeableConcept: CodeableConcept = { coding: [] }
+
+      expect(getFirstCodingCode(codeableConcept, 'NO_CODE')).toBe('NO_CODE')
+    })
+  })
+
+  describe('getFirstCodingSystem', () => {
+    it('should return system from first coding', () => {
+      const codeableConcept: CodeableConcept = {
+        coding: [
+          { system: 'http://example.com/first', code: 'test' },
+          { system: 'http://example.com/second', code: 'test2' },
+        ],
+      }
+
+      expect(getFirstCodingSystem(codeableConcept)).toBe(
+        'http://example.com/first',
+      )
+    })
+
+    it('should handle undefined gracefully', () => {
+      expect(getFirstCodingSystem(undefined)).toBe('')
+    })
+  })
+
+  describe('getFirstCoding', () => {
+    it('should return entire first coding object', () => {
+      const firstCoding: Coding = {
+        system: 'http://example.com',
+        code: 'TEST',
+        display: 'Test Display',
+      }
+
+      const codeableConcept: CodeableConcept = {
+        coding: [firstCoding, { code: 'other' }],
+      }
+
+      expect(getFirstCoding(codeableConcept)).toEqual(firstCoding)
+    })
+
+    it('should return undefined when no coding available', () => {
+      expect(getFirstCoding(undefined)).toBeUndefined()
+      expect(getFirstCoding({})).toBeUndefined()
+      expect(getFirstCoding({ coding: [] })).toBeUndefined()
+    })
+  })
+
+  describe('safeArrayFirst', () => {
+    it('should return first element of array', () => {
+      expect(safeArrayFirst(['a', 'b', 'c'])).toBe('a')
+      expect(safeArrayFirst([1, 2, 3])).toBe(1)
+    })
+
+    it('should return undefined for empty array', () => {
+      expect(safeArrayFirst([])).toBeUndefined()
+    })
+
+    it('should return undefined for undefined array', () => {
+      expect(safeArrayFirst(undefined)).toBeUndefined()
+    })
+
+    it('should handle single element array', () => {
+      expect(safeArrayFirst(['only'])).toBe('only')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle malformed coding arrays', () => {
+      const malformedConcept: CodeableConcept = {
+        // @ts-ignore - testing malformed data
+        coding: [null, undefined, { display: 'Valid' }],
+      }
+
+      // Should still work because of optional chaining
+      expect(getFirstCodingDisplay(malformedConcept)).toBe('Unknown')
+    })
+
+    it('should handle deeply nested undefined values', () => {
+      const concept: CodeableConcept = {
+        coding: [{}], // Empty coding object
+      }
+
+      expect(getFirstCodingDisplay(concept)).toBe('Unknown')
+      expect(getFirstCodingCode(concept)).toBe('')
+      expect(getFirstCodingSystem(concept)).toBe('')
+    })
+  })
+})

--- a/apps/app/src/lib/fhir-utils.ts
+++ b/apps/app/src/lib/fhir-utils.ts
@@ -1,0 +1,60 @@
+import type { CodeableConcept, Coding } from '@medplum/fhirtypes'
+
+/**
+ * Safely extracts the first coding's display value from a CodeableConcept
+ * @param codeableConcept - The CodeableConcept to extract from
+ * @param fallback - Fallback value if no display is found
+ * @returns The display value or fallback
+ */
+export function getFirstCodingDisplay(
+  codeableConcept: CodeableConcept | undefined,
+  fallback = 'Unknown',
+): string {
+  return codeableConcept?.coding?.[0]?.display || fallback
+}
+
+/**
+ * Safely extracts the first coding's code value from a CodeableConcept
+ * @param codeableConcept - The CodeableConcept to extract from
+ * @param fallback - Fallback value if no code is found
+ * @returns The code value or fallback
+ */
+export function getFirstCodingCode(
+  codeableConcept: CodeableConcept | undefined,
+  fallback = '',
+): string {
+  return codeableConcept?.coding?.[0]?.code || fallback
+}
+
+/**
+ * Safely extracts the first coding's system value from a CodeableConcept
+ * @param codeableConcept - The CodeableConcept to extract from
+ * @param fallback - Fallback value if no system is found
+ * @returns The system value or fallback
+ */
+export function getFirstCodingSystem(
+  codeableConcept: CodeableConcept | undefined,
+  fallback = '',
+): string {
+  return codeableConcept?.coding?.[0]?.system || fallback
+}
+
+/**
+ * Safely extracts the first coding object from a CodeableConcept
+ * @param codeableConcept - The CodeableConcept to extract from
+ * @returns The first coding object or undefined
+ */
+export function getFirstCoding(
+  codeableConcept: CodeableConcept | undefined,
+): Coding | undefined {
+  return codeableConcept?.coding?.[0]
+}
+
+/**
+ * Safely gets the first element of an array with proper null checking
+ * @param array - Array to access
+ * @returns First element or undefined
+ */
+export function safeArrayFirst<T>(array: T[] | undefined): T | undefined {
+  return array?.[0]
+}

--- a/apps/app/src/lib/medplum-client.ts
+++ b/apps/app/src/lib/medplum-client.ts
@@ -425,7 +425,7 @@ export class MedplumStoreClient {
         return await this.client.updateResource(updatedTask)
       }
 
-      const displayName = `${Array.isArray(practitioner.name?.[0]?.given) ? practitioner.name[0].given.join(' ') : (practitioner.name?.[0]?.given ?? '')} ${Array.isArray(practitioner.name?.[0]?.family) ? practitioner.name[0].family.join(' ') : (practitioner.name?.[0]?.family ?? '')}`
+      const displayName = `${Array.isArray(practitioner.name?.[0]?.given) ? practitioner.name?.[0]?.given.join(' ') : (practitioner.name?.[0]?.given ?? '')} ${Array.isArray(practitioner.name?.[0]?.family) ? practitioner.name?.[0]?.family.join(' ') : (practitioner.name?.[0]?.family ?? '')}`
 
       // Update the task owner
       const updatedTask = {


### PR DESCRIPTION
- Fix critical crash when clicking tasks with undefined input array by adding optional chaining to task.input?.[0] access in TaskDetails component
- Secure unsafe array access patterns in ConnectorsSection by adding optional chaining to coding array access operations
- Fix unsafe practitioner name array access in medplum-client that could cause crashes during user display name resolution
- Add comprehensive FHIR utility functions with safe array access patterns to prevent future similar issues
- Include comprehensive test coverage for new FHIR utility functions covering edge cases and error scenarios
- Enable production browser source maps in Next.js config for improved error debugging and stack trace visibility

This addresses the TypeError 'Cannot read properties of undefined (reading '0')' that occurred when users clicked on tasks from the patient details modal, and prevents similar array access crashes throughout the application.