### PR TITLE
feat: 🎸 cleanup task enrichment and improve task ingestion

### DIFF
--- a/packages/bots/src/bots/awellhealth/task-enrichment.ts
+++ b/packages/bots/src/bots/awellhealth/task-enrichment.ts
@@ -595,30 +595,6 @@ async function fetchDataPointsForTaskStatus(
   return []
 }
 
-async function updatePatientWithDataPointExtensions(
-  medplum: MedplumClient,
-  task: Task,
-  dataPointExtensions: Extension[],
-): Promise<void> {
-  if (dataPointExtensions.length === 0) return
-
-  const patientId = task.for?.reference?.split('/')[1]
-  if (!patientId) {
-    throw new Error('No patient reference found in task')
-  }
-
-  const patient = await medplum.readResource('Patient', patientId)
-  const mergedExtensions = mergeExtensions(
-    patient.extension || [],
-    dataPointExtensions,
-  )
-
-  await medplum.updateResource({
-    ...patient,
-    extension: mergedExtensions,
-  })
-}
-
 export async function handler(
   medplum: MedplumClient,
   event: BotEvent<Task>,
@@ -705,14 +681,6 @@ export async function handler(
         ...dataPointExtensions,
       ]),
     })
-
-    if (dataPointExtensions.length > 0) {
-      await updatePatientWithDataPointExtensions(
-        medplum,
-        freshTask,
-        dataPointExtensions,
-      )
-    }
 
     console.log(
       `Enrichment completed successfully for task ${task.id}: processed ${dataPoints.length} data points, added ${updatedInputs.length} connector inputs, updated ${dataPointExtensions.length > 0 ? 'patient' : 'task only'}`,


### PR DESCRIPTION
- stop updating patient with datapoints when a task is created (it should be done via datapoints now)
- start doing upset again if the patient doesn't exist (but only if it doesn't exist) so we avoid a race conditions while to many tasks are created at same time while creating the minimal patient record.